### PR TITLE
Added order_id to collection query

### DIFF
--- a/Model/DataMapping/FieldValueRenderer/OrderItem/Name.php
+++ b/Model/DataMapping/FieldValueRenderer/OrderItem/Name.php
@@ -52,7 +52,10 @@ class Name implements RenderInterface
         $childrenItems = $entity->getChildrenItems();
 
         if (!$childrenItems) {
-            $childName = $this->childItems->getChildName((int) $entity->getItemId());
+            $childName = $this->childItems->getChildName(
+                (int) $entity->getOrderId(),
+                (int) $entity->getItemId()
+            );
 
             return $childName ?: $name;
         }

--- a/Model/DataMapping/FieldValueRenderer/OrderItem/VariantId.php
+++ b/Model/DataMapping/FieldValueRenderer/OrderItem/VariantId.php
@@ -63,7 +63,10 @@ class VariantId implements RenderInterface
         $childrenItems = $entity->getChildrenItems();
 
         if (!$childrenItems) {
-            $variantIds = $this->childItems->getChildIds((int) $entity->getItemId());
+            $variantIds = $this->childItems->getChildIds(
+                (int) $entity->getOrderId(),
+                (int) $entity->getItemId()
+            );
 
             return $variantIds ?: [$this->getChildProductId->execute($entity)];
         }

--- a/Model/OrderItem/DiscountAmount.php
+++ b/Model/OrderItem/DiscountAmount.php
@@ -117,7 +117,10 @@ class DiscountAmount
         }
 
         // Used if order items were loaded through a collection
-        $childItemsData = $this->getChildItemsData((int) $orderItem->getItemId());
+        $childItemsData = $this->getChildItemsData(
+            (int) $orderItem->getOrderId(),
+            (int) $orderItem->getItemId()
+        );
 
         foreach ($childItemsData as $childItem) {
             $discountAmount = $childItem[$type] ?? 0.0;
@@ -143,15 +146,16 @@ class DiscountAmount
     /**
      * Returns child item data from database
      *
+     * @param int $orderId
      * @param int $orderItemId
      *
      * @return array
      */
-    private function getChildItemsData(int $orderItemId): array
+    private function getChildItemsData(int $orderId, int $orderItemId): array
     {
         if (!array_key_exists($orderItemId, $this->cachedData)) {
             $this->cachedData = [
-                $orderItemId => $this->childItems->getDiscountData($orderItemId)
+                $orderItemId => $this->childItems->getDiscountData($orderId, $orderItemId)
             ];
         }
 

--- a/Model/OrderItem/GetChildItems.php
+++ b/Model/OrderItem/GetChildItems.php
@@ -45,7 +45,10 @@ class GetChildItems
     {
         $orderItems = $orderItem->getChildrenItems();
 
-        return $orderItems ?: $this->getChildItemsCollection((int) $orderItem->getItemId());
+        return $orderItems ?: $this->getChildItemsCollection(
+            (int) $orderItem->getOrderId(),
+            (int) $orderItem->getItemId()
+        );
     }
 
     /**
@@ -55,7 +58,7 @@ class GetChildItems
      *
      * @return OrderItemInterface[]
      */
-    private function getChildItemsCollection(int $parentId): array
+    private function getChildItemsCollection(int $orderId, int $parentId): array
     {
         if (!array_key_exists($parentId, $this->itemsCollectionCache)) {
             // Clear cache
@@ -63,6 +66,7 @@ class GetChildItems
 
             /** @var Collection $collection */
             $collection = $this->collectionFactory->create();
+            $collection->addFieldToFilter(OrderItemInterface::ORDER_ID, $orderId);
             $collection->addFieldToFilter(OrderItemInterface::PARENT_ITEM_ID, $parentId);
 
             $this->itemsCollectionCache[$parentId] = $collection->getItems();

--- a/Model/ResourceModel/OrderItem/ChildItems.php
+++ b/Model/ResourceModel/OrderItem/ChildItems.php
@@ -39,13 +39,14 @@ class ChildItems
     /**
      * Returns an array of product ids
      *
+     * @param int $orderId
      * @param int $orderItemId
      *
      * @return array
      */
-    public function getChildIds(int $orderItemId): array
+    public function getChildIds(int $orderId, int $orderItemId): array
     {
-        $result = $this->getConnection()->fetchCol($this->getSelect($orderItemId, [OrderItemInterface::PRODUCT_ID]));
+        $result = $this->getConnection()->fetchCol($this->getSelect($orderId, $orderItemId, [OrderItemInterface::PRODUCT_ID]));
 
         return $result ?: [];
     }
@@ -67,19 +68,20 @@ class ChildItems
     /**
      * Returns child item select
      *
+     * @param int $orderId
      * @param int $orderItemId
      * @param array $columns
      *
      * @return Select
      */
-    private function getSelect(int $orderItemId, array $columns): Select
+    private function getSelect(int $orderId, int $orderItemId, array $columns): Select
     {
         $connection = $this->getConnection();
         $select = $connection->select()->reset();
         $select->from(
             $connection->getTableName('sales_order_item'),
             $columns
-        )->where('parent_item_id = ?', $orderItemId);
+        )->where('order_id = ?', $orderId)->where('parent_item_id = ?', $orderItemId);
 
         return $select;
     }
@@ -87,15 +89,17 @@ class ChildItems
     /**
      * Get Child name
      *
+     * @param int $orderId
      * @param int $orderItemId
      *
      * @return string
      */
-    public function getChildName(int $orderItemId): string
+    public function getChildName(int $orderId, int $orderItemId): string
     {
         return (string) $this->getConnection()
             ->fetchOne(
                 $this->getSelect(
+                    $orderId,
                     $orderItemId,
                     [OrderItemInterface::NAME]
                 )
@@ -105,13 +109,15 @@ class ChildItems
     /**
      * Returns data to calculate discount amount
      *
+     * @param int $orderId
      * @param int $orderItemId
      *
      * @return array
      */
-    public function getDiscountData(int $orderItemId): array
+    public function getDiscountData(int $orderId, int $orderItemId): array
     {
         $select = $this->getSelect(
+            $orderId,
             $orderItemId,
             [
                 OrderItemInterface::QTY_ORDERED,


### PR DESCRIPTION
By querying directly on parent_item_id results in a full table scan every time. This causes a severe performance issue when the sales_order_item contains millions of records.

By also querying on order_id, results in just scanning all items in a single order, as this field is indexed.