### PR TITLE
Make sure country name is always tracked in en_US

### DIFF
--- a/Service/Address/GetCountryName.php
+++ b/Service/Address/GetCountryName.php
@@ -43,7 +43,7 @@ class GetCountryName
     {
         if (!array_key_exists($countryCode, $this->countryCache)) {
             $country = $this->countryFactory->create()->loadByCode($countryCode);
-            $this->countryCache[$countryCode] = $country ? (string) $country->getName() : '';
+            $this->countryCache[$countryCode] = $country ? (string) $country->getName("en_US") : '';
         }
 
         return $this->countryCache[$countryCode];


### PR DESCRIPTION
This update is to make sure country names are tracked in the same language across the events to streamline analytics and segmentations.