### PR TITLE
EXP-220: Fixed creating customer imports

### DIFF
--- a/Model/InitialExport/Action/Configure/Import/Request/Entity/Customer.php
+++ b/Model/InitialExport/Action/Configure/Import/Request/Entity/Customer.php
@@ -9,6 +9,7 @@ namespace Bloomreach\EngagementConnector\Model\InitialExport\Action\Configure\Im
 
 use Bloomreach\EngagementConnector\Model\InitialExport\Action\Configure\Import\Request\BuilderInterface;
 use Bloomreach\EngagementConnector\Model\InitialExport\Action\Configure\Import\Request\IdMappingGetter;
+use stdClass;
 
 /**
  * The class is responsible for building request body for Customer entity type
@@ -39,7 +40,7 @@ class Customer implements BuilderInterface
      */
     public function build(string $entityType, array $body = []): array
     {
-        $body['destination'] = ['customer_destination' => []];
+        $body['destination'] = ['customer_destination' => new stdClass()];
         $body['mapping']['column_mapping']['id_mappings'] = $this->idMappingGetter->execute();
 
         return $body;


### PR DESCRIPTION
Customer import can’t be created.
The issue is reproduced for version >= 1.0.0

**Precondition**
- Extension is configured
- Customer Feed is enabled

**Steps to reproduce**
1. Go to Admin panel → Marketing → Bloomreach Engagement Connector → Initial Import
2. Click Configure button for Customer feed
3. Click confirm in confirmation alert

**Actual Result**
- Import is not created
- An error is occurred
![image](https://github.com/user-attachments/assets/4ea095e4-4c31-49e4-8bdd-32c7bd27c434)

**Expected result**
- Import is successfully created
- Import status is changed to Ready